### PR TITLE
✨ Export GetRequestUriIgnoreQueryOrder()

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -149,9 +149,9 @@ func CacheByRequestURI(defaultCacheStore persist.CacheStore, defaultExpire time.
 	var cacheStrategy GetCacheStrategyByRequest
 	if cfg.ignoreQueryOrder {
 		cacheStrategy = func(c *gin.Context) (bool, Strategy) {
-			newUri, err := getRequestUriIgnoreQueryOrder(c.Request.RequestURI)
+			newUri, err := GetRequestUriIgnoreQueryOrder(c.Request.RequestURI)
 			if err != nil {
-				cfg.logger.Errorf("getRequestUriIgnoreQueryOrder error: %s", err)
+				cfg.logger.Errorf("GetRequestUriIgnoreQueryOrder error: %s", err)
 				newUri = c.Request.RequestURI
 			}
 
@@ -173,7 +173,7 @@ func CacheByRequestURI(defaultCacheStore persist.CacheStore, defaultExpire time.
 	return cache(defaultCacheStore, defaultExpire, cfg)
 }
 
-func getRequestUriIgnoreQueryOrder(requestURI string) (string, error) {
+func GetRequestUriIgnoreQueryOrder(requestURI string) (string, error) {
 	parsedUrl, err := url.ParseRequestURI(requestURI)
 	if err != nil {
 		return "", err

--- a/cache_test.go
+++ b/cache_test.go
@@ -192,11 +192,11 @@ func TestWriteHeader(t *testing.T) {
 }
 
 func TestGetRequestUriIgnoreQueryOrder(t *testing.T) {
-	val, err := getRequestUriIgnoreQueryOrder("/test?c=3&b=2&a=1")
+	val, err := GetRequestUriIgnoreQueryOrder("/test?c=3&b=2&a=1")
 	require.NoError(t, err)
 	assert.Equal(t, "/test?a=1&b=2&c=3", val)
 
-	val, err = getRequestUriIgnoreQueryOrder("/test?d=4&e=5")
+	val, err = GetRequestUriIgnoreQueryOrder("/test?d=4&e=5")
 	require.NoError(t, err)
 	assert.Equal(t, "/test?d=4&e=5", val)
 }


### PR DESCRIPTION
ticket: [[Core] 調整 eslitecorp 的 gin-cahe](https://eslite.youtrack.cloud/issue/CT-2103/Core-eslitecorp-gin-cahe)

將 `GetRequestUriIgnoreQueryOrder` export 出去讓外部使用